### PR TITLE
fix: Import useMemo to fix ReferenceError

### DIFF
--- a/app/components/ui/KeyboardShortcuts.tsx
+++ b/app/components/ui/KeyboardShortcuts.tsx
@@ -19,7 +19,7 @@
 
 'use client'
 
-import { useEffect, useCallback, useState } from 'react'
+import { useEffect, useCallback, useState, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import { usePathname } from 'next/navigation'
 import { Dialog, Transition } from '@headlessui/react'


### PR DESCRIPTION
The `KeyboardShortcuts` component was using the `useMemo` hook without importing it from React, which caused a `ReferenceError`.

This change adds `useMemo` to the import statement from `react` in `app/components/ui/KeyboardShortcuts.tsx` to resolve the error.