### PR TITLE
Fix user deletion by updating schema relations

### DIFF
--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -142,36 +142,10 @@ export async function DELETE(
       )
     }
 
-    // Delete user and related data
-    await prisma.$transaction(async (tx) => {
-      // Delete related records first
-      await tx.session.deleteMany({
-        where: { userId }
-      })
-
-      await tx.auditLog.deleteMany({
-        where: { userId }
-      })
-
-      await tx.userPreferences.deleteMany({
-        where: { userId }
-      })
-
-      // Update products and pages to remove user reference
-      await tx.product.updateMany({
-        where: { createdBy: userId },
-        data: { createdBy: 'deleted-user' }
-      })
-
-      await tx.page.updateMany({
-        where: { createdBy: userId },
-        data: { createdBy: 'deleted-user' }
-      })
-
-      // Finally delete the user
-      await tx.user.delete({
-        where: { id: userId }
-      })
+    // The schema is now configured to handle cascading deletes and setting fields to null.
+    // We can directly delete the user.
+    await prisma.user.delete({
+      where: { id: userId },
     })
 
     // Create audit log for user deletion

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -74,12 +74,12 @@ model Product {
   featured          Boolean           @default(false)
   seoTitle          String?           @map("seo_title") @db.VarChar(255)
   seoDescription    String?           @map("seo_description")
-  createdBy         String            @map("created_by") @db.Uuid
+  createdBy         String?           @map("created_by") @db.Uuid
   createdAt         DateTime          @default(now()) @map("created_at")
   updatedAt         DateTime          @updatedAt @map("updated_at")
   categories        ProductCategory[]
   media             ProductMedia[]
-  creator           User              @relation("ProductCreator", fields: [createdBy], references: [id])
+  creator           User?             @relation("ProductCreator", fields: [createdBy], references: [id], onDelete: SetNull)
 
   @@map("products")
 }
@@ -104,9 +104,9 @@ model Media {
   height       Int?
   altText      String?        @map("alt_text") @db.VarChar(255)
   folder       String         @default("uploads") @db.VarChar(255)
-  createdBy    String         @map("created_by") @db.Uuid
+  createdBy    String?        @map("created_by") @db.Uuid
   createdAt    DateTime       @default(now()) @map("created_at")
-  creator      User           @relation("MediaCreator", fields: [createdBy], references: [id])
+  creator      User?          @relation("MediaCreator", fields: [createdBy], references: [id], onDelete: SetNull)
   products     ProductMedia[]
 
   @@map("media")
@@ -135,10 +135,10 @@ model Page {
   seoTitle       String?    @map("seo_title") @db.VarChar(255)
   seoDescription String?    @map("seo_description")
   publishedAt    DateTime?  @map("published_at")
-  createdBy      String     @map("created_by") @db.Uuid
+  createdBy      String?    @map("created_by") @db.Uuid
   createdAt      DateTime   @default(now()) @map("created_at")
   updatedAt      DateTime   @updatedAt @map("updated_at")
-  creator        User       @relation("PageCreator", fields: [createdBy], references: [id])
+  creator        User?      @relation("PageCreator", fields: [createdBy], references: [id], onDelete: SetNull)
 
   @@map("pages")
 }
@@ -148,9 +148,9 @@ model ContentRevision {
   contentType  String   @map("content_type") @db.VarChar(50)
   contentId    String   @map("content_id") @db.Uuid
   revisionData Json     @map("revision_data")
-  createdBy    String   @map("created_by") @db.Uuid
+  createdBy    String?  @map("created_by") @db.Uuid
   createdAt    DateTime @default(now()) @map("created_at")
-  creator      User     @relation(fields: [createdBy], references: [id])
+  creator      User?    @relation(fields: [createdBy], references: [id], onDelete: SetNull)
 
   @@map("content_revisions")
 }
@@ -162,10 +162,10 @@ model ApiKey {
   permissions String[]      @db.VarChar(100)
   isActive    Boolean       @default(true) @map("is_active")
   lastUsed    DateTime?     @map("last_used")
-  createdBy   String        @map("created_by") @db.Uuid
+  createdBy   String?       @map("created_by") @db.Uuid
   createdAt   DateTime      @default(now()) @map("created_at")
   expiresAt   DateTime?     @map("expires_at")
-  creator     User          @relation("ApiKeyCreator", fields: [createdBy], references: [id])
+  creator     User?         @relation("ApiKeyCreator", fields: [createdBy], references: [id], onDelete: SetNull)
   usageLogs   ApiUsageLog[]
 
   @@map("api_keys")
@@ -196,10 +196,10 @@ model Backup {
   checksum    String             @db.VarChar(64)
   version     String             @db.VarChar(20)
   description String?
-  createdBy   String             @map("created_by") @db.Uuid
+  createdBy   String?            @map("created_by") @db.Uuid
   createdAt   DateTime           @default(now()) @map("created_at")
   restoreLogs BackupRestoreLog[]
-  creator     User               @relation("BackupCreator", fields: [createdBy], references: [id])
+  creator     User?              @relation("BackupCreator", fields: [createdBy], references: [id], onDelete: SetNull)
 
   @@map("backups")
 }
@@ -207,10 +207,10 @@ model Backup {
 model BackupRestoreLog {
   id         String   @id @default(uuid()) @db.Uuid
   backupId   String   @map("backup_id") @db.Uuid
-  restoredBy String   @map("restored_by") @db.Uuid
+  restoredBy String?  @map("restored_by") @db.Uuid
   restoredAt DateTime @default(now()) @map("restored_at")
   backup     Backup   @relation(fields: [backupId], references: [id], onDelete: Cascade)
-  restorer   User     @relation("BackupRestorer", fields: [restoredBy], references: [id])
+  restorer   User?    @relation("BackupRestorer", fields: [restoredBy], references: [id], onDelete: SetNull)
 
   @@map("backup_restore_logs")
 }


### PR DESCRIPTION
Previously, an admin could not delete a user if that user had associated records in other tables (e.g., products, pages, media). This was due to missing `onDelete` referential actions in the Prisma schema, which caused foreign key constraint violations in the database.

This commit fixes the issue by:
1.  Updating the `prisma/schema.prisma` file to add `onDelete: SetNull` to the relations between the `User` model and other models like `Product`, `Page`, `Media`, `ApiKey`, `Backup`, `BackupRestoreLog`, and `ContentRevision`. This ensures that when a user is deleted, the corresponding fields in the related tables are set to `NULL` instead of blocking the deletion.
2.  Simplifying the user deletion logic in `app/api/admin/users/[id]/route.ts`. The manual cleanup of related records is no longer necessary, as the database now handles this automatically through the schema's referential actions.