### PR TITLE
Fix(babel): Configure Babel for TypeScript compilation

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,12 +1,7 @@
 module.exports = {
-  env: {
-    test: {
-      presets: [
-        ['@babel/preset-env', {targets: {node: 'current'}}],
-        '@babel/preset-typescript',
-        ['@babel/preset-react', {runtime: 'automatic'}],
-        '@babel/preset-flow'
-      ],
-    }
-  }
+  presets: [
+    ['@babel/preset-env', {targets: {node: 'current'}}],
+    '@babel/preset-typescript',
+    ['@babel/preset-react', {runtime: 'automatic'}],
+  ],
 };


### PR DESCRIPTION
The build was failing with a syntax error in a TypeScript file (`.ts`), indicating that Babel was not correctly configured to handle TypeScript syntax. The error message mentioned 'flow', which was a red herring caused by the misconfiguration.

The `babel.config.js` file only contained a configuration for the `test` environment. When running a build (e.g., `npm run build`), a different environment is used, and Babel was not finding any presets, leading to incorrect parsing.

This commit fixes the issue by providing a top-level `presets` configuration in `babel.config.js` that applies to all environments. It includes the necessary presets for a Next.js TypeScript project: `@babel/preset-env`, `@babel/preset-typescript`, and `@babel/preset-react`.

The `@babel/preset-flow` has been removed as it is not needed for a TypeScript project and was likely contributing to the confusion.

The existing component tests, which rely on this Babel configuration, all pass with this new setup, confirming the change is not a breaking one for the test suite.